### PR TITLE
Register business and get all business

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,14 @@
-# api/__init__.py 
+# api/__init__.py
 
+import uuid
+import requests
 from flask import Flask, request, jsonify, abort, make_response
 
 # Local imports
 from config import app_config
+
+businesses = {}
+reviews = {}
 
 def create_app(config_name):
     app = Flask(__name__, instance_relative_config=True)
@@ -13,11 +18,20 @@ def create_app(config_name):
     from .auth import auth as auth_blueprint
     app.register_blueprint(auth_blueprint, url_prefix='/api/v1/auth')
 
-    # Initialize variables
-    # users, businesses, reviews = {}
+    @app.route('/api/v1/businesses', methods=['POST', 'GET'])
+    def fn_businesses():
+        """Create business and get all businesses"""
+        data = request.get_json()
+        r_business_id = str(uuid.uuid4())
+        if request.method == 'POST':
+            new_business = {"business_id":r_business_id, 
+                "name":data['name'], "location":data['location'], 
+                "web_address":data['web_address'],
+                "category":data['category']}
+            businesses[r_business_id] = new_business
+            return jsonify({"message" : "Business created successfully"}), 201
 
-    @app.route('/businesses/', methods=['POST', 'GET'])
-    def businesses():
-        pass
+        elif request.method == 'GET':
+            return jsonify(businesses)
 
     return app

--- a/test_weconnect.py
+++ b/test_weconnect.py
@@ -12,6 +12,10 @@ class TestAuthentication(unittest.TestCase):
         create_app.testing = True
         self.client = self.app.test_client
         self.test_user = {"username" : "test_user", "password" : "Test123"}
+        self.test_business = {"name" : "Andela Kenya", 
+                                "location" : "Nairobi, Kenya", 
+                                "web_address" : "www.andela.com", 
+                                "category" : "IT"}
 
     def test_register_user(self):
         """Test api can register new user"""
@@ -23,6 +27,19 @@ class TestAuthentication(unittest.TestCase):
     def test_get_users(self):
         """Test api can get all users"""
         response = self.client().get('/api/v1/auth/users')
+        self.assertEqual(response.status_code, 200)
+
+    def test_register_business(self):
+        """Test api can register new business"""
+        response = self.client().post('/api/v1/businesses', 
+            data=json.dumps(self.test_business), 
+                content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+        self.assertIn('Business created', str(response.data))
+
+    def test_get_businesses(self):
+        """Test api can get all businesses"""
+        response = self.client().get('/api/v1/businesses')
         self.assertEqual(response.status_code, 200)
     
 


### PR DESCRIPTION
### What does this PR do?
1. Registers a new business
2. Gets all business in WeConnect system

### Description of Task to be completed?
A user is able to register a new business at WeConnect.
A user is also able to view all businesses that are registered in WeConnect

### How should this be manually tested?
- From Postman, select `POST` HTTP method and type `api/v1/businesses` then supply the necessary fields for a business such as name, location, web address and category then click the `Send` button. This will have a new business created. A message _New business created successfully_ gets printed.
- To see all businesses in the system, change the HTTP method to `GET` then have the same URL above `api/v1/businesses`, then click `Send` button. The businesses will be listed at the bottom of the Postman.

### What are the relevant pivotal tracker stories?
- [User should be able to register business](https://www.pivotaltracker.com/story/show/155539641)
- [User should be able to search for a business](https://www.pivotaltracker.com/story/show/155539759)

### Any background context you want to add?
- N/A

### Screenshots
- N/A
