### PR TITLE
Reset password and logout

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -75,11 +75,11 @@ def reset_password():
     """Reset user password"""
     data = request.get_json()
     users[data["username"]]["password"] = generate_password_hash(data['password'])
-    return jsonify({"message" : "Password reset successfully"})
+    return jsonify({"message" : "Password reset successful"})
 
 @auth.route('/logout', methods=['POST'])
-def logout(current_user):
+def logout():
     """Log user out"""
-    current_user.token = None
+    # Get the token and make it None
     return jsonify({"message": "You are now logged out"})
     

--- a/test_weconnect.py
+++ b/test_weconnect.py
@@ -14,6 +14,8 @@ class TestAuthentication(unittest.TestCase):
         self.login_user = {"username" : "test_user", "password" : "Test123"}
         self.test_user = {"username" : "test_user", "password" : "Test123"}
         self.test1_user = {"username" : "test1_user", "password" : "Test123"}
+        self.reset_user = {"username" : "reset_user", "password" : "Reset123"}
+        self.login_user = {"username" : "login_user", "password" : "Log123"}
         self.test_business = {"name" : "Andela Kenya", 
                                 "user_id": current_user,
                                 "location" : "Nairobi, Kenya", 
@@ -53,21 +55,33 @@ class TestAuthentication(unittest.TestCase):
 
     def test_login_user(self):
         """Test api can login registered user"""
-        self.client().post('/api/v1/auth/login', 
-            data=json.dumps(self.test_user), 
+        self.client().post('/api/v1/auth/register', 
+            data=json.dumps(self.login_user), 
             headers={'content-type':'application/json', 
                     'x-access-token':self.token})
         response = self.client().post('/api/v1/auth/login', 
-            data=json.dumps(self.test_user), content_type='application/json')
+            data=json.dumps(self.login_user), content_type='application/json')
         self.assertEqual(response.status_code, 200)
 
     def test_reset_password(self):
         """Test api can reset user password"""
-        pass
+        self.client().post('/api/v1/auth/register', 
+            data=json.dumps(self.reset_user), 
+            content_type='application/json')
+        response = self.client().post('/api/v1/auth/reset-password', 
+            data=json.dumps(self.reset_user), 
+            content_type='application/json')
+        self.reset_user['password'] = "ResetAgain12"
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Password reset successful", str(response.data))
+        
 
     def test_logout_user(self):
         """Test api can logout user"""
-        pass
+        response = self.client().post('/api/v1/auth/logout', 
+            data=json.dumps(self.login_user), content_type='application/json')
+        self.assertIn("You are now logged out", str(response.data))
+        self.assertEqual(response.status_code, 200)
 
     def test_register_and_get_business(self):
         """Test api can register new business"""


### PR DESCRIPTION
### What does this PR do?
Resets the user's password and logs user 

### Description of Task to be completed
User is able to reset the password by providing a new one, and alsolog out of the system.

### How should this be manually tested?
On Postman, select `POST` HTTP method and enter the password in JSON format in the body section, enter the URL `/api/v1/auth/reset-password` then click `Send` button to reset the password.
Select `POST` HTTP method, enter the URL `/api/v1/auth/logout` and click `Send` button to log out. This has not yet been implemented nicely, though

### What are the relevant pivotal tracker stories?
- [Reset password](https://www.pivotaltracker.com/story/show/155786335)
- [Logout user](https://www.pivotaltracker.com/story/show/155786489)
- [Challenge 2](https://docs.google.com/document/d/1iJrCZKiHl-9bIqsTinHmipI_ItYZgrPHT2ZzO3W7ACg/edit#)

### Any background context you want to add?
- N/A

### Screenshots
- N/A